### PR TITLE
Add "Update AniDB Calendar" action

### DIFF
--- a/src/core/api/v3/actions.ts
+++ b/src/core/api/v3/actions.ts
@@ -82,6 +82,11 @@ function getSyncMyList() {
   return ApiRequest('SyncMyList');
 }
 
+// Update AniDB Calendar
+function getUpdateAnidbCalendar() {
+  return ApiRequest('UpdateAniDBCalendar');
+}
+
 // Update All AniDB Series Info
 function getUpdateAllAniDBInfo() {
   return ApiRequest('UpdateAllAniDBInfo');
@@ -112,6 +117,7 @@ export default {
   getDownloadMissingAniDBAnimeData,
   getRegenerateAllTvDBEpisodeMatchings,
   getSyncMyList,
+  getUpdateAnidbCalendar,
   getUpdateAllAniDBInfo,
   getUpdateAllMediaInfo,
   getUpdateSeriesStats,

--- a/src/core/quick-actions.ts
+++ b/src/core/quick-actions.ts
@@ -11,6 +11,10 @@ const quickActions = {
     name: 'Download Missing AniDB Data',
     function: 'getDownloadMissingAniDBAnimeData',
   },
+  'update-anidb-calendar': {
+    name: 'Update AniDB Calendar',
+    function: 'getUpdateAnidbCalendar',
+  },
   'update-all-anidb-info': {
     name: 'Update All AniDB Info',
     function: 'getUpdateAllAniDBInfo',

--- a/src/core/slices/webuiSettings.ts
+++ b/src/core/slices/webuiSettings.ts
@@ -68,7 +68,7 @@ export const defaultLayout = {
   } as LayoutType,
   actions: {
     lg: [{
-      i: 'anidb', x: 0, y: 0, w: 4, h: 9, minW: 3, minH: 5, maxH: 10, moved: false, static: false,
+      i: 'anidb', x: 0, y: 0, w: 4, h: 9, minW: 3, minH: 5, maxH: 12, moved: false, static: false,
     }, {
       i: 'shoko', x: 4, y: 0, w: 4, h: 9, minW: 3, minH: 5, maxH: 10, moved: false, static: false,
     }, {

--- a/src/pages/actions/ActionsPage.tsx
+++ b/src/pages/actions/ActionsPage.tsx
@@ -19,6 +19,7 @@ const actions = {
       'sync-votes',
       'sync-mylist',
       'update-all-anidb-info',
+      'update-anidb-calendar',
     ],
   },
   trakt: {


### PR DESCRIPTION
Add "Update AniDB Calendar" action to manually trigger an update for the dashboard calendar.

It's useful for those who want to update the calendar but don't run the automatic update event periodically, or if you need to update it immediately for whatever reason. 