### PR TITLE
Fix crash in UpcomingAnime

### DIFF
--- a/src/pages/dashboard/panels/UpcomingAnime.tsx
+++ b/src/pages/dashboard/panels/UpcomingAnime.tsx
@@ -13,7 +13,7 @@ const UpcomingAnime = () => {
     <ShokoPanel isFetching={items.isFetching} title={<DashboardTitleToggle title="Upcoming Anime" mainTitle="My Collection" secondaryTitle="All" secondaryActive={showAll} setSecondaryActive={setShowAll} />}>
       <div className="flex flex-nowrap overflow-x-auto shoko-scrollbar h-90 pb-5">
         {items.data?.length === 0 && <div className="flex justify-center font-semibold mt-4">It Looks like Your Not Watching Anything Currently Airing.</div>}
-        {items.data?.map(item => <EpisodeDetails episode={item} showDate key={item.IDs.ID} />)}
+        {items.data?.map(item => item.IDs && <EpisodeDetails episode={item} showDate key={item.IDs.ID} />)}
       </div>
     </ShokoPanel>
   );


### PR DESCRIPTION
I'm running the latest stable version of Docker Shoko server

When logging into the WebUI, I get the following crash

![image](https://user-images.githubusercontent.com/1142161/193480437-d0ee2706-28e4-47ff-bf7d-6976de039e6a.png)

If I log the `items` in `UpcomingAnime.tsx` I get the following:
![image](https://user-images.githubusercontent.com/1142161/193480460-aa9074e2-c7ac-4f52-bedd-bb49637b4dee.png)

Which has no `items.data.IDs` property (hence the crash) and looks nothing like a `DashboardEpisodeDetailsType` that `EpisodeDetails` is expecting.

I imagine that this is because I'm running a version of Shoko server that's out of sync from the Web-UI, but if we release the Web-UI and users haven't updated data on their server they're likely to run into this?