### PR TITLE
WIP: Edit dashboard menu

### DIFF
--- a/src/components/Dialogs/EditDashboardModal.tsx
+++ b/src/components/Dialogs/EditDashboardModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import ModalPanel from '../Panels/ModalPanel';
+import { setStatus } from '../../core/slices/modals/editDashboard';
+
+import { RootState } from '../../core/store';
+
+function EditDashboardModal() {
+  const dispatch = useDispatch();
+  const status = useSelector((state: RootState) => state.modals.editDashboard.status);
+  const handleClose = () => dispatch(setStatus(false));
+
+  return (
+    <ModalPanel
+      show={status}
+      className="pb-6"
+      onRequestClose={() => handleClose()}
+    >
+      <div className="flex flex-col w-full border-l border-background-border drop-shadow-[4px_0_4px_rgba(0,0,0,0.25)]">
+        <div className="flex flex-col items-center justify-start bg-color-nav">
+          HELLO WORLD
+        </div>
+      </div>
+    </ModalPanel>
+  );
+}
+
+export default EditDashboardModal;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   mdiHelpCircleOutline,
   mdiGithub,
   mdiLogout,
+  mdiCircleEditOutline,
 } from '@mdi/js';
 import { siDiscord } from 'simple-icons/icons';
 
@@ -23,6 +24,7 @@ import Events from '../../core/events';
 import { setStatus } from '../../core/slices/modals/profile';
 import { setStatus as setActionsStatus } from '../../core/slices/modals/actions';
 import { setStatus as setUtilitiesStatus } from '../../core/slices/modals/utilities';
+import { setStatus as setEditDashboardStatus } from '../../core/slices/modals/editDashboard';
 import { default as ShokoIcon } from '../ShokoIcon';
 
 function Sidebar() {
@@ -47,13 +49,14 @@ function Sidebar() {
     );
   };
 
-  const renderMenuItem = (key: string, text: string, icon: string) => {
+  const renderMenuItem = (key: string, text: string, icon: string, additionalNav?: { icon: string, onClick: () => void }) => {
     const uri = `/webui/${key}`;
     const isHighlighted = pathname.startsWith(uri);
     return (
       <Link key={key} className={cx(['cursor-pointer flex items-center w-full px-7', isHighlighted && 'text-highlight-1'])} to={uri}>
         <div className="w-6 flex items-center mr-6 my-3"><Icon path={icon} size={1} horizontal vertical rotate={180}/></div>
         <span className="text-lg">{text}</span>
+        {additionalNav && <div className="w-6 flex items-center ml-3 my-3" onClick={additionalNav.onClick}><Icon path={additionalNav.icon} size={1} horizontal vertical rotate={180}/></div>}
       </Link>
     );
   };
@@ -78,7 +81,7 @@ function Sidebar() {
         <span className="text-highlight-2 text-lg">{(queueItems.HasherQueueCount + queueItems.GeneralQueueCount + queueItems.ImageQueueCount) ?? 0}</span>
       </div>
       <div className="flex flex-col justify-between mt-11 w-full">
-        {renderMenuItem('dashboard', 'Dashboard', mdiTabletDashboard)}
+        {renderMenuItem('dashboard', 'Dashboard', mdiTabletDashboard, { icon: mdiCircleEditOutline, onClick: () => dispatch(setEditDashboardStatus(true)) })}
         {renderMenuItem('collection', 'Collection', mdiLayersTripleOutline)}
         {renderNonLinkMenuItem('utilities', 'Utilities', mdiTools, () => dispatch(setUtilitiesStatus(true)))}
         {renderNonLinkMenuItem('actions', 'Actions', mdiFormatListBulletedSquare, () => dispatch(setActionsStatus(true)))}

--- a/src/core/slices/modals.ts
+++ b/src/core/slices/modals.ts
@@ -7,6 +7,7 @@ import profileReducer from './modals/profile';
 import filtersReducer from './modals/filters';
 import actionsReducer from './modals/actions';
 import utilitiesReducer from './modals/utilities';
+import editDashboardReducer from './modals/editDashboard';
 
 export default combineReducers({
   browseFolder: browseFolderReducer,
@@ -16,4 +17,5 @@ export default combineReducers({
   filters: filtersReducer,
   actions: actionsReducer,
   utilities: utilitiesReducer,
+  editDashboard: editDashboardReducer,
 });

--- a/src/core/slices/modals/editDashboard.ts
+++ b/src/core/slices/modals/editDashboard.ts
@@ -1,0 +1,21 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type State = {
+  status: boolean;
+};
+
+const  editDashboardSlice = createSlice({
+  name: 'editDashboard',
+  initialState: {
+    status: false,
+  } as State,
+  reducers: {
+    setStatus(sliceState, action: PayloadAction<boolean>) {
+      sliceState.status = action.payload;
+    },
+  },
+});
+
+export const { setStatus } = editDashboardSlice.actions;
+
+export default editDashboardSlice.reducer;

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -24,8 +24,8 @@ function DashboardPage() {
   const dispatch = useDispatch();
 
   const layout = useSelector((state: RootState) => state.webuiSettings.webui_v2.layout.dashboard);
-
   const [currentLayout, setCurrentLayout] = useState(defaultLayout.dashboard);
+  const [isEditable, setIsEditable] = useState<boolean>(false);
 
   useEffect(() => {
     setCurrentLayout(layout);
@@ -47,6 +47,9 @@ function DashboardPage() {
         lg: 12, md: 10, sm: 6, xs: 4, xxs: 2,
       }}
       rowHeight={0}
+      isDraggable={isEditable}
+      isResizable={isEditable}
+      isDroppable={isEditable}
       containerPadding={[36, 36]}
       margin={[26, 26]}
       className="w-full"

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -25,7 +25,7 @@ function DashboardPage() {
 
   const layout = useSelector((state: RootState) => state.webuiSettings.webui_v2.layout.dashboard);
   const [currentLayout, setCurrentLayout] = useState(defaultLayout.dashboard);
-  const [isEditable, setIsEditable] = useState<boolean>(false);
+  const [isEditable, setIsEditable] = useState<boolean>(true);
 
   useEffect(() => {
     setCurrentLayout(layout);

--- a/src/pages/dashboard/panels/UpcomingAnime.tsx
+++ b/src/pages/dashboard/panels/UpcomingAnime.tsx
@@ -13,7 +13,7 @@ const UpcomingAnime = () => {
     <ShokoPanel isFetching={items.isFetching} title={<DashboardTitleToggle title="Upcoming Anime" mainTitle="My Collection" secondaryTitle="All" secondaryActive={showAll} setSecondaryActive={setShowAll} />}>
       <div className="flex flex-nowrap overflow-x-auto shoko-scrollbar h-90 pb-5">
         {items.data?.length === 0 && <div className="flex justify-center font-semibold mt-4">It Looks like Your Not Watching Anything Currently Airing.</div>}
-        {items.data?.map(item => <EpisodeDetails episode={item} showDate key={item.IDs.ID} />)}
+        {items.data?.map(item => item.IDs && <EpisodeDetails episode={item} showDate key={item.IDs.ID} />)}
       </div>
     </ShokoPanel>
   );

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -14,6 +14,7 @@ import ProfileModal from '../../components/Dialogs/ProfileModal';
 import FiltersModal from '../../components/Dialogs/FiltersModal';
 import ActionsModal from '../../components/Dialogs/ActionsModal';
 import UtilitiesModal from '../../components/Dialogs/UtilitiesModal';
+import EditDashboardModal from '../../components/Dialogs/EditDashboardModal';
 
 function MainPage() {
   const dispatch = useDispatch();
@@ -52,6 +53,7 @@ function MainPage() {
         <FiltersModal />
         <ActionsModal />
         <UtilitiesModal />
+        <EditDashboardModal />
         <div className="flex">
           <Sidebar />
         </div>


### PR DESCRIPTION
Don't bother linting this just yet, it will fail

This is a WIP PR to show what I've got so far for the edit dashboard menu.

So far I've got:
- An icon to toggle the modal on/off
  - The way the icon is rendered is not ideal and doesn't look the best, but I've heard the nav is being updated so I didn't want to touch too much there
- Some boilerplate for the editDashboard modal reducer
- Clicking the icon will open a basic modal _on the right-hand side of the page_
- A little PoC in the Dashboard page to prove to myself that it's possible to disable editing of the dashboard

![image](https://user-images.githubusercontent.com/1142161/193505657-35cc2073-077b-428f-9068-16daeaae43e5.png)


Immediate next steps:
- Create a "edit dashboard" toggle in the modal
- Clicking the toggle should make the dashboard editable
- If the dashboard is editable, there should be a toast somewhere telling the user they're in edit mode