### PR TITLE
Add fallback output for when there are zero manually linked files

### DIFF
--- a/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
+++ b/src/pages/utilities/UnrecognizedUtilityTabs/ManuallyLinkedTab.tsx
@@ -134,7 +134,7 @@ function ManuallyLinkedTab() {
           <div className="flex h-full justify-center items-center">
             <Icon path={mdiLoading} size={4} className="text-highlight-1" spin />
           </div>
-        ) : (
+        ) : series.Total > 0 ? (
           <React.Fragment>
             <div className="flex px-8 py-3.5 bg-background-nav drop-shadow-lg font-bold sticky top-0 z-[1]">
               Series Name
@@ -173,6 +173,8 @@ function ManuallyLinkedTab() {
               </div>
             </div>
           </React.Fragment>
+        ) : (
+          <div className="flex items-center justify-center h-full font-semibold">No manually linked file(s)!</div> 
         )}
       </div>
     </TransitionDiv>


### PR DESCRIPTION
As I seem to type on all my PRs, there's probably a better way of doing this but making simple small changes is the way I roll!

This change should prevent the `TypeError: virtualItems[0] is undefined` error from appearing on the manually linked files tab when there are no manually linked files in Shoko.

I've tested this on my machine™ with this change, starting from having no manually linked files to then manually linking a file in the unrecognised files tab, unlinking it from the manually linked tab and finally deleting the file back on the unrecognised files tab without any errors being thrown at any point.