### PR TITLE
revert: "series episodes api changes, fix unrecognized (#507)"

### DIFF
--- a/src/core/rtkQuery/splitV3Api/seriesApi.ts
+++ b/src/core/rtkQuery/splitV3Api/seriesApi.ts
@@ -37,13 +37,13 @@ const seriesApi = splitV3Api.injectEndpoints({
 
     // Get the Shoko.Server.API.v3.Models.Shoko.Episodes for the Shoko.Server.API.v3.Models.Shoko.Series with seriesID.
     getSeriesEpisodes: build.query<ListResultType<EpisodeType[]>, { seriesId: number; } & PaginationType>({
-      query: ({ seriesId, ...params }) => ({ url: `Series/${seriesId}/Episode?includeDataFrom=AniDB&includeDataFrom=TvDB`, params }),
+      query: ({ seriesId, ...params }) => ({ url: `Series/${seriesId}/Episode?includeMissing=true&includeDataFrom=AniDB&includeDataFrom=TvDB`, params }),
       providesTags: ['SeriesEpisodes', 'UtilitiesRefresh'],
     }),
 
     // Get the Shoko.Server.API.v3.Models.Shoko.Episodes for the Shoko.Server.API.v3.Models.Shoko.Series with seriesID.
     getSeriesEpisodesInfinite: build.query<ListResultType<EpisodeType[]>, { seriesId: number; } & PaginationType>({
-      query: ({ seriesId, ...params }) => ({ url: `Series/${seriesId}/Episode?includeDataFrom=AniDB&includeDataFrom=TvDB`, params }),
+      query: ({ seriesId, ...params }) => ({ url: `Series/${seriesId}/Episode?includeMissing=true&includeDataFrom=AniDB&includeDataFrom=TvDB`, params }),
       // Only have one cache entry because the arg always maps to one string
       serializeQueryArgs: ({ endpointName }) => {
         return endpointName;


### PR DESCRIPTION
This reverts commit 8c1009e990a9a7c1289208c03a59eb777c9724ad because the hot-fix for shoko server (4.2.1) makes the old behaviour the correct behaviour.