### PR TITLE
feat: Add missing quick actions to v1

### DIFF
--- a/src/core/api/v3/actions.ts
+++ b/src/core/api/v3/actions.ts
@@ -12,11 +12,6 @@ function getRunImport() {
   return ApiRequest('RunImport');
 }
 
-// This was for web cache hash syncing, and will be for perceptual hashing maybe eventually.
-function getSyncHashes() {
-  return ApiRequest('SyncHashes');
-}
-
 // Sync the votes from Shoko to AniDB.
 function getSyncVotes() {
   return ApiRequest('SyncVotes');
@@ -102,9 +97,19 @@ function getImportNewFiles() {
   return ApiRequest('ImportNewFiles');
 }
 
+// Forcibly schedules commands to add the files to MyList for all manual linked files.
+function getAddAllManualLinksToMyList() {
+  return ApiRequest('AddAllManualLinksToMyList');
+}
+
+// Update AniDB Files with missing file info, including with missing release groups and/or with
+// out-of-date internal data versions.
+function getUpdateMissingAniDBFileInfo(outOfDate: boolean) {
+  return ApiRequest(`UpdateMissingAniDBFileInfo?missingInfo=true&outOfDate=${outOfDate}`);
+}
+
 export default {
   getRunImport,
-  getSyncHashes,
   getSyncVotes,
   getSyncTrakt,
   getRemoveMissingFiles,
@@ -123,4 +128,6 @@ export default {
   getPlexSyncAll,
   getRecreateAllGroups,
   getImportNewFiles,
+  getAddAllManualLinksToMyList,
+  getUpdateMissingAniDBFileInfo,
 };

--- a/src/core/quick-actions.ts
+++ b/src/core/quick-actions.ts
@@ -7,6 +7,10 @@ const quickActions = {
     name: 'Sync AniDB MyList',
     function: 'getSyncMyList',
   },
+  'add-all-manually-linked-files-to-mylist': {
+    name: 'Add All Manual Links To MyList',
+    function: 'getAddAllManualLinksToMyList',
+  },
   'download-missing-anidb-data': {
     name: 'Download Missing AniDB Data',
     function: 'getDownloadMissingAniDBAnimeData',
@@ -47,9 +51,15 @@ const quickActions = {
     name: 'Update Series Stats',
     function: 'getUpdateSeriesStats',
   },
-  'sync-hashes': {
-    name: 'Sync Hashes',
-    function: 'getSyncHashes',
+  'update-missing-anidb-file-release-groups': {
+    name: 'Update Missing AniDB Release Groups',
+    function: 'getUpdateMissingAniDBFileInfo',
+    data: false,
+  },
+  'update-missing-anidb-file-info': {
+    name: 'Update Missing AniDB File Info',
+    function: 'getUpdateMissingAniDBFileInfo',
+    data: true,
   },
   'update-all-images': {
     name: 'Update All Images',

--- a/src/pages/main/Tabs/ActionsTab.tsx
+++ b/src/pages/main/Tabs/ActionsTab.tsx
@@ -21,6 +21,7 @@ const actions = {
       'download-missing-anidb-data',
       'sync-votes',
       'sync-mylist',
+      'add-all-manually-linked-files-to-mylist',
       'update-all-anidb-info',
     ],
   },
@@ -49,7 +50,8 @@ const actions = {
     data: [
       'avdump-mismatched-files',
       'recreate-all-groups',
-      'sync-hashes',
+      'update-missing-anidb-file-release-groups',
+      'update-missing-anidb-file-info',
       'update-all-mediainfo',
       'update-series-stats',
     ],


### PR DESCRIPTION
Same as #521 but for v1. Also, "Import New Files" were already added to v1 but not to master.