### PR TITLE
fix: don't display specials if there are none

### DIFF
--- a/src/pages/collection/Series.tsx
+++ b/src/pages/collection/Series.tsx
@@ -101,14 +101,18 @@ const Series = () => {
             <div className="space-x-2 flex">
               <Icon path={mdiFileDocumentMultipleOutline} size={1} />
               <span>{series?.Sizes.Local.Episodes} / {series?.Sizes.Total.Episodes}</span>
-              <span className="px-2">|</span>
-              <span>{series?.Sizes.Local.Specials} / {series?.Sizes.Total.Specials}</span>
+              {series?.Sizes.Total.Specials ?? 0 > 0 ? (<>
+                <span className="px-2">|</span>
+                <span>{series?.Sizes.Local.Specials} / {series?.Sizes.Total.Specials}</span>
+              </>) : null}
             </div>
             <div className="space-x-2 flex">
               <Icon path={mdiEyeOutline} size={1} />
               <span>{series?.Sizes.Watched.Episodes} / {series?.Sizes.Total.Episodes}</span>
-              <span className="px-2">|</span>
-              <span>{series?.Sizes.Watched.Specials} / {series?.Sizes.Total.Specials}</span>
+              {series?.Sizes.Total.Specials ?? 0 > 0 ? (<>
+                <span className="px-2">|</span>
+                <span>{series?.Sizes.Watched.Specials} / {series?.Sizes.Total.Specials}</span>
+              </>) : null}
             </div>
           </div>
           <div className="mt-5 space-x-4 flex flex-nowrap">


### PR DESCRIPTION
because EC said it was a bug, and I determined it to be a client side UI bug, so I did a PoC fix instead of just telling you there was a bug.